### PR TITLE
Update README to reflect q2's dependency on outdated packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Installation
 The new version of `q2` can only be installed via pip. Simply try:
 
 ```bash
-pip install qoyllur-quipu
+pip install qoyllur-quipu scipy==1.5.4 numpy==1.14.5
 ```
 
 If you have installed the old version of `q2`, you must delete it from your HOME directory and also remove its PATH from bashrc (.bash_profile for Mac OS). Once you have installed `q2`, open a Jupyter Notebook Environment (or iPython) and import `q2`.
@@ -37,7 +37,7 @@ If you have installed the old version of `q2`, you must delete it from your HOME
 import q2
 ```
 
-By importing `q2`, the latest version of <a href="http://www.as.utexas.edu/~chris/moog.html">MOOG</a> (2019) will begin to install. The only thing you need to do is declare the kind of machine you are using, i.g., 'rh64' for 64-bit linux (Linux Mint, Ubuntu, etc), 'rh' for 32-bit linux system and 'maclap' for Mac Os. That's all folks. This process is done only once. Note that the `q2` package requires Python 3.7 or later. 
+By importing `q2`, the latest version of <a href="http://www.as.utexas.edu/~chris/moog.html">MOOG</a> (2019) will begin to install. The only thing you need to do is declare the kind of machine you are using, i.g., 'rh64' for 64-bit linux (Linux Mint, Ubuntu, etc), 'rh' for 32-bit linux system and 'maclap' for Mac Os. That's all folks. This process is done only once. Note that the `q2` package requires Python 3.7. 
     
 The current version of q2 is 1.0.2, so please upgrade it via:
 


### PR DESCRIPTION
This library only works with python3.7 (due to relying on outdated numpy features) and has put my friend through a lot of grief trying to work out what was going wrong! We've debugged it and came to the conclusion it works with the exact dependency versions I've specified in this PR, I've also changed the text that it works with python3.7 or later, to saying it just works with python3.7

It might also be possible to just change the requirements file rather than changing the readme's install command but I could not find where this was